### PR TITLE
⚡ Bolt: Lazy load map components via IntersectionObserver

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-03-07 - [Lazy Loading Maps with Intersection Observer]
+**Learning:** Initial React.lazy for map components is good, but without tying it to an intersection observer, the heavy leaflet libraries are loaded as soon as the component is mounted in the DOM, even if they are far off-screen.
+**Action:** Used `IntersectionObserver` via a custom hook to defer rendering the map until it approaches the viewport (using a 200px rootMargin buffer), significantly reducing the critical rendering path load for pages containing off-screen maps.

--- a/src/components/LazyMap.tsx
+++ b/src/components/LazyMap.tsx
@@ -1,6 +1,7 @@
-import React, { Suspense, lazy } from 'react'
+import React, { Suspense, lazy, useRef } from 'react'
 import { Skeleton, Box } from '@mui/material'
 import { Event } from '../types'
+import { useIntersectionObserver } from '../hooks/useIntersectionObserver'
 
 // Lazy imports
 const SingleEventMap = lazy(() =>
@@ -28,19 +29,43 @@ interface LazySingleEventMapProps {
 
 export const LazySingleEventMap: React.FC<LazySingleEventMapProps> = ({
   event
-}) => (
-  <Suspense fallback={<MapSkeleton />}>
-    <SingleEventMap event={event} />
-  </Suspense>
-)
+}) => {
+  const ref = useRef<HTMLDivElement>(null)
+  const entry = useIntersectionObserver(ref, { freezeOnceVisible: true, rootMargin: '200px' })
+  const isVisible = !!entry?.isIntersecting
+
+  return (
+    <Box ref={ref} sx={{ minHeight: 300, height: '100%' }}>
+      {isVisible ? (
+        <Suspense fallback={<MapSkeleton />}>
+          <SingleEventMap event={event} />
+        </Suspense>
+      ) : (
+        <MapSkeleton />
+      )}
+    </Box>
+  )
+}
 
 // Wrapper for EventMap
 interface LazyEventMapProps {
   events: Event[]
 }
 
-export const LazyEventMap: React.FC<LazyEventMapProps> = (props) => (
-  <Suspense fallback={<MapSkeleton />}>
-    <EventMap {...props} />
-  </Suspense>
-)
+export const LazyEventMap: React.FC<LazyEventMapProps> = (props) => {
+  const ref = useRef<HTMLDivElement>(null)
+  const entry = useIntersectionObserver(ref, { freezeOnceVisible: true, rootMargin: '200px' })
+  const isVisible = !!entry?.isIntersecting
+
+  return (
+    <Box ref={ref} sx={{ minHeight: 300, height: '100%' }}>
+      {isVisible ? (
+        <Suspense fallback={<MapSkeleton />}>
+          <EventMap {...props} />
+        </Suspense>
+      ) : (
+        <MapSkeleton />
+      )}
+    </Box>
+  )
+}

--- a/src/hooks/useIntersectionObserver.ts
+++ b/src/hooks/useIntersectionObserver.ts
@@ -1,0 +1,39 @@
+import { useState, useEffect, RefObject } from 'react'
+
+interface Args extends IntersectionObserverInit {
+  freezeOnceVisible?: boolean
+}
+
+export function useIntersectionObserver(
+  elementRef: RefObject<Element | null>,
+  {
+    threshold = 0,
+    root = null,
+    rootMargin = '0%',
+    freezeOnceVisible = false,
+  }: Args
+): IntersectionObserverEntry | undefined {
+  const [entry, setEntry] = useState<IntersectionObserverEntry>()
+
+  const frozen = entry?.isIntersecting && freezeOnceVisible
+
+  const updateEntry = ([entry]: IntersectionObserverEntry[]): void => {
+    setEntry(entry)
+  }
+
+  useEffect(() => {
+    const node = elementRef?.current
+    const hasIOSupport = !!window.IntersectionObserver
+
+    if (!hasIOSupport || frozen || !node) return
+
+    const observerParams = { threshold, root, rootMargin }
+    const observer = new IntersectionObserver(updateEntry, observerParams)
+
+    observer.observe(node)
+
+    return () => observer.disconnect()
+  }, [elementRef, threshold, root, rootMargin, frozen])
+
+  return entry
+}


### PR DESCRIPTION
💡 **What**: Implemented `useIntersectionObserver` to defer loading `react-leaflet` Maps (`SingleEventMap` and `EventMap`) until they are within 200px of the viewport.

🎯 **Why**: Using `React.lazy` inside `Suspense` without an intersection check triggers loading immediately when the component renders, even if it's off-screen. Maps are heavy resources (loading Leaflet library and tiles). Loading them only when necessary speeds up the initial page load, reduces network traffic, and frees up the main thread during critical rendering.

📊 **Impact**: Expected significant reduction in Time to Interactive (TTI) and initial page load on event pages (especially on mobile) by deferring Map dependency parsing and execution.

🔬 **Measurement**: Inspect the Network tab in DevTools. The Leaflet resources and map tiles should not load until the user scrolls down to the map section on an Event details page.

📝 **Journal Entry**: Added an entry in `.jules/bolt.md` documenting this optimization pattern for lazy loading heavy off-screen resources.

---
*PR created automatically by Jules for task [16193174668602183662](https://jules.google.com/task/16193174668602183662) started by @Shotafry*