### PR TITLE
⚡ Bolt: Add lazy loading to EventCard images

### DIFF
--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -112,6 +112,7 @@ export const EventCard: React.FC<EventCardProps> = memo(({ event }) => {
           <Box
             component='img'
             className='event-logo'
+          loading='lazy' // Defers loading the image until it is near the viewport, improving initial load time and saving bandwidth for off-screen event cards.
             src={
               event.card_image_url ||
               event.image_url ||


### PR DESCRIPTION
💡 What: Added the native HTML `loading="lazy"` attribute to the image component in `EventCard`.

🎯 Why: The `EventCard` component is used in lists that can be very long (e.g., on the Landing Page and Organization events). Eagerly loading all these images wastes bandwidth and degrades initial page load performance, as many images might be below the fold and never seen.

📊 Impact: Defers loading of off-screen event card images. This leads to a faster initial page load time and reduces overall network payload and memory usage, particularly beneficial on mobile devices or slow connections.

🔬 Measurement: Inspecting the DOM elements of the events cards (e.g., using developer tools on the landing page) will show `loading="lazy"` on the `<img />` tags corresponding to the event logos. Network tabs will show images are only requested when scrolling down to them.

---
*PR created automatically by Jules for task [3349375874521627358](https://jules.google.com/task/3349375874521627358) started by @Shotafry*