### PR TITLE
🛡️ Sentinel: [SECURITY ENHANCEMENT] Fix reverse tabnabbing on external links

### DIFF
--- a/src/components/about/JoinTeamCTA.tsx
+++ b/src/components/about/JoinTeamCTA.tsx
@@ -224,6 +224,7 @@ const JoinTeamCTA: React.FC = () => {
                   <Button
                     href={card.ctaLink}
                     target='_blank'
+                    rel='noopener noreferrer'
                     variant={
                       card.variant === 'primary' ? 'secondary' : 'primary'
                     }

--- a/src/components/collaborators/CollaboratorCard.tsx
+++ b/src/components/collaborators/CollaboratorCard.tsx
@@ -75,6 +75,7 @@ export const CollaboratorCard: React.FC<CollaboratorProps> = ({
             <IconButton
               href={social.linkedin}
               target='_blank'
+              rel='noopener noreferrer'
               size='small'
               sx={{
                 color: '#0A66C2',
@@ -88,6 +89,7 @@ export const CollaboratorCard: React.FC<CollaboratorProps> = ({
             <IconButton
               href={social.github}
               target='_blank'
+              rel='noopener noreferrer'
               size='small'
               sx={{
                 color: '#333',

--- a/src/components/social/ConnectButton.tsx
+++ b/src/components/social/ConnectButton.tsx
@@ -734,6 +734,7 @@ export const ConnectButton = ({
                     size='small'
                     href={`https://t.me/${contactInfo.telegram.replace('@', '')}`}
                     target='_blank'
+                    rel='noopener noreferrer'
                     sx={{
                       minWidth: 'auto',
                       p: 1,

--- a/src/pages/AboutUs.tsx
+++ b/src/pages/AboutUs.tsx
@@ -192,6 +192,7 @@ const AboutUs: React.FC = () => {
                       <IconButton
                         href={member.social.linkedin}
                         target='_blank'
+                        rel='noopener noreferrer'
                         sx={{
                           color: '#0A66C2',
                           '&:hover': { bgcolor: 'rgba(10, 102, 194, 0.1)' }
@@ -202,6 +203,7 @@ const AboutUs: React.FC = () => {
                       <IconButton
                         href={member.social.github}
                         target='_blank'
+                        rel='noopener noreferrer'
                         sx={{
                           color: '#333',
                           '&:hover': { bgcolor: 'rgba(51, 51, 51, 0.1)' }

--- a/src/pages/PanelDeUsuario.tsx
+++ b/src/pages/PanelDeUsuario.tsx
@@ -283,6 +283,7 @@ const PanelDeUsuario: FunctionComponent = () => {
               variant='primary'
               href={`/u/${user?.slug || user?.id}`}
               target='_blank'
+              rel='noopener noreferrer'
               startIcon={<PersonIcon />}
               size='small'
               sx={{

--- a/src/pages/organization-profile/components/OrgHeader.tsx
+++ b/src/pages/organization-profile/components/OrgHeader.tsx
@@ -161,6 +161,7 @@ export const OrgHeader: React.FC<OrgHeaderProps> = ({
             <IconButton
               href={socialLinks.twitter}
               target='_blank'
+              rel='noopener noreferrer'
               size='small'
               sx={{
                 color: '#000000',
@@ -176,6 +177,7 @@ export const OrgHeader: React.FC<OrgHeaderProps> = ({
             <IconButton
               href={socialLinks.linkedin}
               target='_blank'
+              rel='noopener noreferrer'
               size='small'
               sx={{
                 color: '#0A66C2',
@@ -191,6 +193,7 @@ export const OrgHeader: React.FC<OrgHeaderProps> = ({
             <IconButton
               href={socialLinks.github}
               target='_blank'
+              rel='noopener noreferrer'
               size='small'
               sx={{
                 color: '#333',

--- a/src/pages/panel-usuario/tabs/ProfileTab.tsx
+++ b/src/pages/panel-usuario/tabs/ProfileTab.tsx
@@ -75,6 +75,7 @@ export const ProfileTab: React.FC<ProfileTabProps> = ({
         <Button
           href={`/u/${user?.slug || user?.id}`}
           target='_blank'
+          rel='noopener noreferrer'
           size='small'
           variant='secondary'
           sx={{


### PR DESCRIPTION
🚨 Severity: ENHANCEMENT
💡 Vulnerability: External links opening in a new tab without `rel="noopener noreferrer"` can expose the site to reverse tabnabbing attacks where the new tab can manipulate the window that opened it.
🎯 Impact: This improves the defense-in-depth posture of the application by ensuring the `window.opener` object is nullified for external domains.
🔧 Fix: Added `rel='noopener noreferrer'` to all instances of `target='_blank'` using external or potentially untrusted URLs.
✅ Verification: Ensure the links continue to open correctly in a new tab and tests pass.

---
*PR created automatically by Jules for task [5506555088885869653](https://jules.google.com/task/5506555088885869653) started by @Shotafry*